### PR TITLE
Add an `install_dependencies` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-You can pass additional arguments to `eleventy` through the `args` option:
+This action accepts a couple of optional inputs:
+
+| Input Name             | Required? | Default | Description                                                            |
+| ---------------------- | :-------: | :-----: | ---------------------------------------------------------------------- |
+| `args`                 |    No     |  `""`   | Arguments to pass to the Eleventy invocation                           |
+| `install_dependencies` |    No     | `false` | If set to `true`, `npm install` will be run before Eleventy is invoked |
+
+For example:
 
 ```yaml
 - name: Build
   uses: TartanLlama/actions-eleventy@v1.1
   with:
-    args: <additional arguments>
+    args: --output _dist
+    install_dependencies: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
   args:
     description: 'Arguments to pass to the Eleventy invocation'
     required: false
+  install_dependencies:
+    description: 'If set to `true`, `npm install` will be run before Eleventy is invoked'
+    required: false
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 
+if [ "$INPUT_INSTALL_DEPENDENCIES" = "true" ]; then
+  echo "Running \`npm install\`"
+  npm install
+fi
+
 echo "Running eleventy"
 eleventy $INPUT_ARGS


### PR DESCRIPTION
This adds a new input, `install_dependencies`, which, when set to `true`, results in dependencies listed in the Eleventy project's `package.json` to be installed before building the site. This is useful for projects which require packages other than just Eleventy during the build process.

These changes also include some updates to the README which mention this new input.