### PR TITLE
Update example to use ubuntu-latest instead of a specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ on: [push]
 
 jobs:
   build_deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - name: Build


### PR DESCRIPTION
I copied the example and Actions was taking ages to start running the build (15 min before I got bored). 

Switching to `ubuntu-latest` got it running immediately. Hopefully this helps the next person.