### PR TITLE
Update Dockerfile to node 22

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -3,14 +3,14 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - name: Build
-        uses: TartanLlama/actions-eleventy@master
+        uses: patrickweaver/actions-eleventy@master
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v1.1.0
         env:
-          PUBLISH_DIR: _site 
+          PUBLISH_DIR: _site
           PUBLISH_BRANCH: gh-pages
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:22-alpine
 RUN npm install -g @11ty/eleventy --unsafe-perm
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Action for Eleventy
 
-Use this action to build your static website with [Eleventy](https://www.11ty.io/).
+Use this action to build your static website with [Eleventy](https://www.11ty.dev/).
 
 To use it, create a `.github/workflows/eleventy_build.yml` file which [uses this repository](https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idsteps) as an action.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build
-        uses: TartanLlama/actions-eleventy@master
+        uses: patrickweaver/actions-eleventy@master
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -36,7 +36,7 @@ For example:
 
 ```yaml
 - name: Build
-  uses: TartanLlama/actions-eleventy@v1.3
+  uses: patrickweaver/actions-eleventy@v1.3
   with:
     args: "--output=_dist"
     install_dependencies: true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ on: [push]
 
 jobs:
   build_deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - name: Build
@@ -20,7 +20,7 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          publish_dir: _site 
+          publish_dir: _site
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -38,6 +38,6 @@ For example:
 - name: Build
   uses: TartanLlama/actions-eleventy@v1.3
   with:
-    args: --output _dist
+    args: "--output=_dist"
     install_dependencies: true
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For example:
 
 ```yaml
 - name: Build
-  uses: patrickweaver/actions-eleventy@v1.3
+  uses: patrickweaver/actions-eleventy@master
   with:
     args: "--output=_dist"
     install_dependencies: true


### PR DESCRIPTION
Eleventy will no longer build with node < 18. With this change I was able to continue to use the action.

Forgot to do this PR from a branch, updated version: https://github.com/TartanLlama/actions-eleventy/pull/15/files