### PR TITLE
Update Dockerfile to node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:22-alpine
 RUN npm install -g @11ty/eleventy --unsafe-perm
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Eleventy will no longer build with node < 18. With this change I was able to continue to use the action.